### PR TITLE
Bugfix: permission key not being set on setup

### DIFF
--- a/src/sublime/cli/subcommand.py
+++ b/src/sublime/cli/subcommand.py
@@ -239,7 +239,7 @@ def feedback(
         help="Default save directory for items retrieved from your Sublime environment")
 def setup(api_key="", save_dir=""):
     """Configure defaults."""
-    config = {"api_key": api_key, "save_dir": save_dir}
+    config = {"api_key": api_key, "save_dir": save_dir, "permission": ""}
     save_config(config)
     click.echo("Configuration saved to {!r}".format(CONFIG_FILE))
 

--- a/src/sublime/util.py
+++ b/src/sublime/util.py
@@ -88,12 +88,12 @@ def save_config(config):
     # If either value was not specified, load the existing values saved
     # to ensure we don't overwrite their values to null here
     saved_config = load_config()
-    if not config["api_key"]:
-        config["api_key"] = saved_config["api_key"]
-    if not config["save_dir"]:
-        config["save_dir"] = saved_config["save_dir"]
-    if not config["permission"]:
-        config["permission"] = saved_config["permission"]
+    if 'api_key' not in config or not config['api_key']:
+        config['api_key'] = saved_config['api_key']
+    if 'save_dir' not in config or not config['save_dir']:
+        config['save_dir'] = saved_config['save_dir']
+    if 'permission' not in config or not config['permission']:
+        config['permission'] = saved_config['permission']
 
     if config["save_dir"] and not os.path.isdir(config["save_dir"]):
         click.echo("Error: save directory is not a valid directory")


### PR DESCRIPTION
Include this in the setup subcommand and do an existence check in
`save_config()` as a failsafe
